### PR TITLE
Binder basic infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
+[![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/elichad/software-twilight/main?urlpath=apps%2Findex.ipynb)
+
 # software-twilight
 Software end of project plans 

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,4 @@
+channels:
+  - conda-forge
+dependencies:
+  - appmode

--- a/index.ipynb
+++ b/index.ipynb
@@ -1,0 +1,36 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    ""
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}


### PR DESCRIPTION
Adds the basic infrastructure to launch the `index.ipnb` notebook in Appmode within MyBinder.org. 

The link in the badge will only work when merged into the main branch. 